### PR TITLE
handled case where input filename doesn't end with EOL 

### DIFF
--- a/change_rf_for.py
+++ b/change_rf_for.py
@@ -34,8 +34,8 @@ def format_file(name):
         added_lines = 0
 
         # Append newline if file doesn't end with \n
-        if '\n' not in content[len(content) - 1]:
-            content[len(content) - 1] += line_ending
+        if '\n' not in content[-1]:
+            content[-1] += line_ending
             content.append(line_ending)
 
         for i, line in enumerate(content):

--- a/change_rf_for.py
+++ b/change_rf_for.py
@@ -22,10 +22,21 @@ def format_file(name):
 
     with open(name, mode='r', newline='', encoding='utf8') as fp:
         content = fp.readlines()
-        line_ending = '\r\n' if '\r\n' in content[0] else '\n'    # no special treatment for Mac ;)
-        in_block = False
 
+        # skip empty files
+        if not content:
+            return False
+
+        line_ending = '\r\n' if '\r\n' in content[0] else '\n'    # no special treatment for Mac ;)
+
+        in_block = False
+        for_position = None
         added_lines = 0
+
+        # Append newline if file doesn't end with \n
+        if '\n' not in content[len(content) - 1]:
+            content[len(content) - 1] += line_ending
+            content.append(line_ending)
 
         for i, line in enumerate(content):
             stripped = line.lstrip().lower()
@@ -36,7 +47,7 @@ def format_file(name):
                     content[i] = ' ' * for_position + 'END' + line_ending + content[i]
                     line = content[i]
                     added_lines += 1
-                    
+
                 for_position = line.find(':')
                 line = line[0:for_position] + line[for_position + 1:]
 
@@ -55,14 +66,14 @@ def format_file(name):
                 if has_slash:
                     pos = line.find('\\')
                     # replace the \ with an whitespace - this will preserve the indentation
-                    content[i] = line[:pos] + ' ' + line[pos+1:]
+                    content[i] = line[:pos] + ' ' + line[pos + 1:]
                 elif stripped.startswith('...') or stripped.startswith('#') \
                         or next_lines_in_block(content[i:]):
                     pass
                 else:       # presumably a line not in the current FOR block? close the block
                     in_block = False
                     # add the new closing keyword, as a new line
-                    content[i] = ' '*for_position + 'END' + line_ending + content[i]
+                    content[i] = ' ' * for_position + 'END' + line_ending + content[i]
                     added_lines += 1
 
             elif has_slash:
@@ -79,9 +90,9 @@ if __name__ == '__main__':
     if len(sys.argv) != 2:
         __, script_name = os.path.split(sys.argv[0])
         print('Pass the target file name as argument; supports glob patterns:')
-        print(f'\t{script_name} directory/suite.robot     - modify a single file')
-        print(f'\t{script_name} directory/*.robot         - modify all files ending with robot')
-        print(f'\t{script_name} directory/**/*.robot      - modify all files ending with robot, in all sub-directories')
+        print(f'\t{script_name} directory/suite.robot       - modify a single file')
+        print(f'\t{script_name} \'directory/*.robot\'         - modify all files ending with robot')
+        print(f'\t{script_name} \'directory/**/*.robot\'      - modify all files ending with robot, in all sub-directories')
         print('The file(s) is modified in-place.')
         exit(0)
 


### PR DESCRIPTION
Hi Todor,

thanks a lot for the script.. It showed an error when the file doesn't end with a newline, and the last line happened to be a for loop, i.e.:

<img width="403" alt="image" src="https://user-images.githubusercontent.com/22439451/65854102-f0068900-e35b-11e9-9cf5-96e73c64eedd.png">

For this case, the script doesn't do anything.

```
(cxta) OBOEHMER-M-Q07G:robotframework-new-for-syntax oboehmer$ python change_rf_for.py ~/Desktop/tmp/for.robot
INFO: /Users/oboehmer/Desktop/tmp/for.robot was not modified.
(cxta) OBOEHMER-M-Q07G:robotframework-new-for-syntax oboehmer$
```

If the file contains a loop earlier, it converts the 2nd loop, but it doesn't end it with an END, which is bad ;-)

<img width="371" alt="image" src="https://user-images.githubusercontent.com/22439451/65854035-b3d32880-e35b-11e9-8a55-61bccca7defb.png">

```
(cxta) OBOEHMER-M-Q07G:robotframework-new-for-syntax oboehmer$ python change_rf_for.py ~/Desktop/tmp/for.robot
INFO: /Users/oboehmer/Desktop/tmp/for.robot was modified.
(cxta) OBOEHMER-M-Q07G:robotframework-new-for-syntax oboehmer$ cat ~/Desktop/tmp/for.robot
*** Test Cases ***
test1
      FOR  ${test}  IN  cat  dog
           Log ${animal}
           Log  2nd keyword
      END

test2
      FOR  ${test}  IN  cat  dog
           Log ${animal}
           Log  2nd keyword(cxta) OBOEHMER-M-Q07G:robotframework-new-for-syntax oboehmer$
```

I fixed this by ensuring that the file ends with newline. I also skip emtpy files..

I also added a few cosmetic changes to make lint happy, and also added `''` around the arguments in the help text to prevent the shell from expanding wildcard
